### PR TITLE
Add frames to publishing messages.

### DIFF
--- a/octomap_world/src/octomap_manager.cc
+++ b/octomap_world/src/octomap_manager.cc
@@ -85,6 +85,9 @@ void OctomapManager::publishAll() {
   getOctomapBinaryMsg(&binary_map);
   getOctomapFullMsg(&full_map);
 
+  binary_map.header.frame_id = world_frame_;
+  full_map.header.frame_id = world_frame_;
+
   binary_map_pub_.publish(binary_map);
   full_map_pub_.publish(full_map);
 }


### PR DESCRIPTION
This allows you to actually use the octomap plugin in rviz, which is way faster than visualizing markers. My machine does not IMMEDIATELY slow to a halt!
