### PR TITLE
Feature/get occlusion

### DIFF
--- a/octomap_world/include/octomap_world/octomap_world.h
+++ b/octomap_world/include/octomap_world/octomap_world.h
@@ -84,6 +84,7 @@ class OctomapWorld : public WorldBase {
       const Eigen::Vector3d& point,
       const Eigen::Vector3d& bounding_box_size) const;
   virtual CellStatus getCellStatusPoint(const Eigen::Vector3d& point) const;
+  virtual CellStatus getCellProbabilityPoint(const Eigen::Vector3d& point, double* probability) const;
   virtual CellStatus getLineStatus(const Eigen::Vector3d& start,
                                    const Eigen::Vector3d& end) const;
   virtual CellStatus getVisibility(const Eigen::Vector3d& view_point,

--- a/octomap_world/src/octomap_world.cc
+++ b/octomap_world/src/octomap_world.cc
@@ -229,6 +229,26 @@ OctomapWorld::CellStatus OctomapWorld::getCellStatusPoint(
   }
 }
 
+OctomapWorld::CellStatus OctomapWorld::getCellProbabilityPoint(
+    const Eigen::Vector3d& point, double* probability) const {
+  octomap::OcTreeNode* node = octree_->search(point.x(), point.y(), point.z());
+  if (node == NULL) {
+    if (probability) {
+      *probability = -1.0;
+    }
+    return CellStatus::kUnknown;
+  } else {
+    if (probability) {
+      *probability = node->getOccupancy();
+    }
+    if (octree_->isNodeOccupied(node)) {
+      return CellStatus::kOccupied;
+    } else {
+      return CellStatus::kFree;
+    }
+  }
+}
+
 OctomapWorld::CellStatus OctomapWorld::getLineStatus(
     const Eigen::Vector3d& start, const Eigen::Vector3d& end) const {
   // Get all node keys for this line.


### PR DESCRIPTION
I propose to have a method to check visibility of a certain voxel. This can not yet be achieved using the getLineStatus method, as occupied voxels would always return CellStatus::kOccupied
