### PR TITLE
fix bug that pcl position is depending on movement of agent

### DIFF
--- a/octomap_world/src/octomap_world.cc
+++ b/octomap_world/src/octomap_world.cc
@@ -372,7 +372,7 @@ void OctomapWorld::getOccupiedPointcloudInBoundingBox(
   Eigen::Vector3d epsilon_3d;
   epsilon_3d.setConstant(epsilon);
 
-  // Get correct center of voxel.
+  // Determine correct center of voxel.
   const Eigen::Vector3d center_corrected(resolution*std::floor(center.x()/resolution) + 
       resolution/2.0, resolution*std::floor(center.y()/resolution) + resolution/2.0,
       resolution*std::floor(center.z()/resolution) + resolution/2.0);


### PR DESCRIPTION
In the original implementation, the local point cloud is moving, depending on the movement of the center (usually this is the UAV position setpoint). The problem is that the points of the pcl are not centered in the center of the Voxel and can move freely within (finite) Voxel volume. The problem is that the points are moving with the same speed as the agent -> this has a significant effect on the potential field based obstacle avoidance. 

This is changed now. Now, the point corresponding the an individual voxel remain at the same spot, not matter what the motion of the agent is.
