### PR TITLE
Fix/ignore old pointclouds

### DIFF
--- a/octomap_world/src/octomap_manager.cc
+++ b/octomap_world/src/octomap_manager.cc
@@ -307,7 +307,7 @@ bool OctomapManager::lookupTransform(const std::string& from_frame,
   // etc).
   if (!tf_listener_.canTransform(to_frame, from_frame, time_to_lookup)) {
     ros::Duration timestamp_age = ros::Time::now() - time_to_lookup;
-    if (timestamp_age > tf_listener_.getCacheLength()) {
+    if (timestamp_age < tf_listener_.getCacheLength()) {
       time_to_lookup = ros::Time(0);
       ROS_WARN("Using latest TF transform instead of timestamp match.");
     }

--- a/octomap_world/src/octomap_manager.cc
+++ b/octomap_world/src/octomap_manager.cc
@@ -312,7 +312,7 @@ bool OctomapManager::lookupTransform(const std::string& from_frame,
       ROS_WARN("Using latest TF transform instead of timestamp match.");
     }
     else {
-      ROS_WARN("Tried to look up transform older than cache limit.");
+      ROS_ERROR("Requested transform time older than cache limit.");
       return false;
     }
   }

--- a/octomap_world/src/octomap_manager.cc
+++ b/octomap_world/src/octomap_manager.cc
@@ -306,8 +306,15 @@ bool OctomapManager::lookupTransform(const std::string& from_frame,
   // the latest (this is to work with bag files and static transform publisher,
   // etc).
   if (!tf_listener_.canTransform(to_frame, from_frame, time_to_lookup)) {
-    time_to_lookup = ros::Time(0);
-    ROS_WARN("Using latest TF transform instead of timestamp match.");
+    ros::Duration timestamp_age = ros::Time::now() - time_to_lookup;
+    if (timestamp_age > tf_listener_.getCacheLength()) {
+      time_to_lookup = ros::Time(0);
+      ROS_WARN("Using latest TF transform instead of timestamp match.");
+    }
+    else {
+      ROS_WARN("Tried to look up transform older than cache limit.");
+      return false;
+    }
   }
 
   try {


### PR DESCRIPTION
The lookupTransform() function currently assumes that the only reason for canTransform() to fail is a lookup in the future. 
However, this can also fail if the requested time is older than the cache limit of the tf_listener. 
This issue caused insertion of misaligned scans, since old pointclouds were inserted with the most recent transforms.

These changes distinguish between the two cases and fails the lookup if an old transform is requested. 