### PR TITLE
Threaded insertion

### DIFF
--- a/octomap_world/include/octomap_world/octomap_manager.h
+++ b/octomap_world/include/octomap_world/octomap_manager.h
@@ -144,7 +144,7 @@ class OctomapManager : public OctomapWorld {
   std::atomic<bool> new_point_cloud_ready_;
   std::mutex point_cloud_insertion_mutex_;
 
-  static constexpr double kThreadRate = 10;
+  static constexpr double kInsertionThreadRate = 10;
 
   // Only calculate Q matrix for disparity once.
   bool Q_initialized_;

--- a/octomap_world/include/octomap_world/octomap_manager.h
+++ b/octomap_world/include/octomap_world/octomap_manager.h
@@ -39,6 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <volumetric_msgs/SaveMap.h>
 #include <volumetric_msgs/SetBoxOccupancy.h>
 #include <volumetric_msgs/SetDisplayBounds.h>
+#include <mutex>
 
 namespace volumetric_mapping {
 
@@ -59,6 +60,9 @@ class OctomapManager : public OctomapWorld {
       const stereo_msgs::DisparityImageConstPtr& disparity);
   void insertPointcloudWithTf(
       const sensor_msgs::PointCloud2::ConstPtr& pointcloud);
+
+  // Data insertion thread
+  void insertPointCloudThread();
 
   // Camera info callbacks.
   void leftCameraInfoCallback(const sensor_msgs::CameraInfoPtr& left_info);
@@ -132,6 +136,12 @@ class OctomapManager : public OctomapWorld {
   // Keep state of the cameras.
   sensor_msgs::CameraInfoPtr left_info_;
   sensor_msgs::CameraInfoPtr right_info_;
+
+  // Variables for pointcloud insertion thread
+  sensor_msgs::PointCloud2::ConstPtr current_pointcloud_;
+  Transformation current_transform_;
+  bool new_pointcloud_ready_;
+  std::mutex pointcloud_insertion_mutex_;
 
   // Only calculate Q matrix for disparity once.
   bool Q_initialized_;

--- a/octomap_world/include/octomap_world/octomap_manager.h
+++ b/octomap_world/include/octomap_world/octomap_manager.h
@@ -32,6 +32,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "octomap_world/octomap_world.h"
 
+#include <atomic>
+#include <mutex>
+
 #include <octomap_msgs/GetOctomap.h>
 #include <std_srvs/Empty.h>
 #include <tf/transform_listener.h>
@@ -39,8 +42,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <volumetric_msgs/SaveMap.h>
 #include <volumetric_msgs/SetBoxOccupancy.h>
 #include <volumetric_msgs/SetDisplayBounds.h>
-#include <mutex>
-#include <atomic>
 
 namespace volumetric_mapping {
 
@@ -59,10 +60,9 @@ class OctomapManager : public OctomapWorld {
   // Data insertion callbacks with TF frame resolution through the listener.
   void insertDisparityImageWithTf(
       const stereo_msgs::DisparityImageConstPtr& disparity);
-  void pointCloudCallback(
-      const sensor_msgs::PointCloud2::ConstPtr& pointcloud);
+  void pointCloudCallback(const sensor_msgs::PointCloud2::ConstPtr& point_cloud);
 
-  // Data insertion thread
+  // Data insertion thread.
   void insertPointCloudThread();
 
   // Camera info callbacks.
@@ -138,11 +138,13 @@ class OctomapManager : public OctomapWorld {
   sensor_msgs::CameraInfoPtr left_info_;
   sensor_msgs::CameraInfoPtr right_info_;
 
-  // Variables for pointcloud insertion thread
-  sensor_msgs::PointCloud2::ConstPtr current_pointcloud_;
+  // Variables for pointcloud insertion thread.
+  sensor_msgs::PointCloud2::ConstPtr current_point_cloud_;
   Transformation current_transform_;
-  std::atomic<bool> new_pointcloud_ready_;
-  std::mutex pointcloud_insertion_mutex_;
+  std::atomic<bool> new_point_cloud_ready_;
+  std::mutex point_cloud_insertion_mutex_;
+
+  static constexpr double kThreadRate = 10;
 
   // Only calculate Q matrix for disparity once.
   bool Q_initialized_;

--- a/octomap_world/include/octomap_world/octomap_manager.h
+++ b/octomap_world/include/octomap_world/octomap_manager.h
@@ -59,7 +59,7 @@ class OctomapManager : public OctomapWorld {
   // Data insertion callbacks with TF frame resolution through the listener.
   void insertDisparityImageWithTf(
       const stereo_msgs::DisparityImageConstPtr& disparity);
-  void insertPointcloudWithTf(
+  void pointCloudCallback(
       const sensor_msgs::PointCloud2::ConstPtr& pointcloud);
 
   // Data insertion thread

--- a/octomap_world/include/octomap_world/octomap_manager.h
+++ b/octomap_world/include/octomap_world/octomap_manager.h
@@ -40,6 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <volumetric_msgs/SetBoxOccupancy.h>
 #include <volumetric_msgs/SetDisplayBounds.h>
 #include <mutex>
+#include <atomic>
 
 namespace volumetric_mapping {
 
@@ -140,7 +141,7 @@ class OctomapManager : public OctomapWorld {
   // Variables for pointcloud insertion thread
   sensor_msgs::PointCloud2::ConstPtr current_pointcloud_;
   Transformation current_transform_;
-  bool new_pointcloud_ready_;
+  std::atomic<bool> new_pointcloud_ready_;
   std::mutex pointcloud_insertion_mutex_;
 
   // Only calculate Q matrix for disparity once.

--- a/octomap_world/src/octomap_manager.cc
+++ b/octomap_world/src/octomap_manager.cc
@@ -301,7 +301,7 @@ void OctomapManager::pointCloudCallback(
 }
 
 void OctomapManager::insertPointCloudThread() {
-  ros::Rate rate(kThreadRate);
+  ros::Rate rate(kInsertionThreadRate);
   while (ros::ok()) {
     if (new_point_cloud_ready_) {
       pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_pointcloud(

--- a/octomap_world/src/octomap_manager.cc
+++ b/octomap_world/src/octomap_manager.cc
@@ -133,7 +133,7 @@ void OctomapManager::subscribe() {
   disparity_sub_ = nh_.subscribe(
       "disparity", 40, &OctomapManager::insertDisparityImageWithTf, this);
   pointcloud_sub_ = nh_.subscribe(
-      "pointcloud", 1, &OctomapManager::insertPointcloudWithTf, this);
+      "pointcloud", 40, &OctomapManager::insertPointcloudWithTf, this);
 }
 
 void OctomapManager::advertiseServices() {
@@ -301,6 +301,7 @@ void OctomapManager::insertPointcloudWithTf(
 }
 
 void OctomapManager::insertPointCloudThread() {
+  ros::Rate rate(10);
   while (ros::ok()) {
     if (new_pointcloud_ready_) {
       pointcloud_insertion_mutex_.lock();
@@ -313,6 +314,7 @@ void OctomapManager::insertPointCloudThread() {
 
       insertPointcloud(sensor_to_world, pcl_pointcloud);
     }
+    else rate.sleep();
   }
 }
 

--- a/octomap_world/src/octomap_manager.cc
+++ b/octomap_world/src/octomap_manager.cc
@@ -133,7 +133,7 @@ void OctomapManager::subscribe() {
   disparity_sub_ = nh_.subscribe(
       "disparity", 40, &OctomapManager::insertDisparityImageWithTf, this);
   pointcloud_sub_ = nh_.subscribe(
-      "pointcloud", 40, &OctomapManager::insertPointcloudWithTf, this);
+      "pointcloud", 40, &OctomapManager::pointCloudCallback, this);
 }
 
 void OctomapManager::advertiseServices() {
@@ -286,7 +286,7 @@ void OctomapManager::insertDisparityImageWithTf(
   }
 }
 
-void OctomapManager::insertPointcloudWithTf(
+void OctomapManager::pointCloudCallback(
     const sensor_msgs::PointCloud2::ConstPtr& pointcloud) {
   // Look up transform from sensor frame to world frame.
   Transformation sensor_to_world;

--- a/octomap_world/src/octomap_manager_node.cc
+++ b/octomap_world/src/octomap_manager_node.cc
@@ -41,9 +41,10 @@ int main(int argc, char** argv) {
 
   volumetric_mapping::OctomapManager manager(nh, nh_private);
 
-  std::thread insert_pointcloud_thread(&volumetric_mapping::OctomapManager::insertPointCloudThread, &manager);
+  std::thread insert_pointcloud_thread(
+      &volumetric_mapping::OctomapManager::insertPointCloudThread, &manager);
 
-  ros::MultiThreadedSpinner spinner(7);
+  ros::MultiThreadedSpinner spinner;
   spinner.spin();
 
   insert_pointcloud_thread.join();

--- a/octomap_world/src/octomap_manager_node.cc
+++ b/octomap_world/src/octomap_manager_node.cc
@@ -43,7 +43,8 @@ int main(int argc, char** argv) {
 
   std::thread insert_pointcloud_thread(&volumetric_mapping::OctomapManager::insertPointCloudThread, &manager);
 
-  ros::spin();
+  ros::MultiThreadedSpinner spinner(7);
+  spinner.spin();
 
   insert_pointcloud_thread.join();
 

--- a/octomap_world/src/octomap_manager_node.cc
+++ b/octomap_world/src/octomap_manager_node.cc
@@ -27,6 +27,8 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#include <thread>
+
 #include "octomap_world/octomap_manager.h"
 
 int main(int argc, char** argv) {
@@ -39,6 +41,11 @@ int main(int argc, char** argv) {
 
   volumetric_mapping::OctomapManager manager(nh, nh_private);
 
+  std::thread insert_pointcloud_thread(&volumetric_mapping::OctomapManager::insertPointCloudThread, &manager);
+
   ros::spin();
+
+  insert_pointcloud_thread.join();
+
   return 0;
 }


### PR DESCRIPTION
Transforms for point clouds are only requested when the callback for pointclouds is called. 
Since insertion is currently called inside the callback this blocks future callbacks. 
If point cloud insertion takes a long time this can lead to point clouds being older than the tf_listener cache length and therefore fails the transform lookup.

This seperates callback and insertion to ensure that transforms are requested as soon as point clouds are published
