### PR TITLE
Added parameter to limit calculation of maximum free space update in ray casting.

### DIFF
--- a/octomap_world/include/octomap_world/octomap_world.h
+++ b/octomap_world/include/octomap_world/octomap_world.h
@@ -49,6 +49,7 @@ struct OctomapParameters {
         threshold_max(0.97),
         threshold_occupancy(0.7),
         filter_speckles(true),
+        max_free_space(5.0),
         sensor_max_range(5.0),
         visualize_min_z(-std::numeric_limits<double>::max()),
         visualize_max_z(std::numeric_limits<double>::max()),
@@ -72,6 +73,9 @@ struct OctomapParameters {
 
   // Filter neighbor-less nodes as 'speckles'.
   bool filter_speckles;
+
+  // Maximum range to allow a free space update.
+  double max_free_space;
 
   // Maximum range to allow a sensor measurement. Negative values to not
   // filter.

--- a/octomap_world/include/octomap_world/octomap_world.h
+++ b/octomap_world/include/octomap_world/octomap_world.h
@@ -50,6 +50,7 @@ struct OctomapParameters {
         threshold_occupancy(0.7),
         filter_speckles(true),
         max_free_space(5.0),
+        min_height_free_space(0.0),
         sensor_max_range(5.0),
         visualize_min_z(-std::numeric_limits<double>::max()),
         visualize_max_z(std::numeric_limits<double>::max()),
@@ -76,6 +77,9 @@ struct OctomapParameters {
 
   // Maximum range to allow a free space update.
   double max_free_space;
+  
+  // Minimum height below sensor to allow a free space update.
+  double min_height_free_space;
 
   // Maximum range to allow a sensor measurement. Negative values to not
   // filter.

--- a/octomap_world/include/octomap_world/octomap_world.h
+++ b/octomap_world/include/octomap_world/octomap_world.h
@@ -49,7 +49,7 @@ struct OctomapParameters {
         threshold_max(0.97),
         threshold_occupancy(0.7),
         filter_speckles(true),
-        max_free_space(5.0),
+        max_free_space(0.0),
         min_height_free_space(0.0),
         sensor_max_range(5.0),
         visualize_min_z(-std::numeric_limits<double>::max()),

--- a/octomap_world/src/octomap_manager.cc
+++ b/octomap_world/src/octomap_manager.cc
@@ -88,6 +88,8 @@ void OctomapManager::setParametersFromROS() {
                     params.filter_speckles);
   nh_private_.param("max_free_space", params.max_free_space,
                     params.max_free_space);
+  nh_private_.param("min_height_free_space", params.min_height_free_space,
+                    params.min_height_free_space);
   nh_private_.param("sensor_max_range", params.sensor_max_range,
                     params.sensor_max_range);
   nh_private_.param("visualize_min_z", params.visualize_min_z,

--- a/octomap_world/src/octomap_manager.cc
+++ b/octomap_world/src/octomap_manager.cc
@@ -86,6 +86,8 @@ void OctomapManager::setParametersFromROS() {
                     params.threshold_occupancy);
   nh_private_.param("filter_speckles", params.filter_speckles,
                     params.filter_speckles);
+  nh_private_.param("max_free_space", params.max_free_space,
+                    params.max_free_space);
   nh_private_.param("sensor_max_range", params.sensor_max_range,
                     params.sensor_max_range);
   nh_private_.param("visualize_min_z", params.visualize_min_z,

--- a/octomap_world/src/octomap_world.cc
+++ b/octomap_world/src/octomap_world.cc
@@ -165,7 +165,11 @@ void OctomapWorld::castRay(const octomap::point3d& sensor_origin,
     // Cast a ray to compute all the free cells.
     octomap::KeyRay key_ray;
     if (octree_->computeRayKeys(sensor_origin, point, key_ray)) {
-      free_cells->insert(key_ray.begin(), key_ray.end());
+      for (const auto& key: key_ray) {
+        if ((octree_->keyToCoord(key) - sensor_origin).norm() < params_.max_free_space) {
+          free_cells->insert(key);
+        }
+      }
     }
     // Mark endpoing as occupied.
     octomap::OcTreeKey key;

--- a/octomap_world/src/octomap_world.cc
+++ b/octomap_world/src/octomap_world.cc
@@ -166,7 +166,9 @@ void OctomapWorld::castRay(const octomap::point3d& sensor_origin,
     octomap::KeyRay key_ray;
     if (octree_->computeRayKeys(sensor_origin, point, key_ray)) {
       for (const auto& key: key_ray) {
-        if ((octree_->keyToCoord(key) - sensor_origin).norm() < params_.max_free_space) {
+	    octomap::point3d voxel_coordinate = octree_->keyToCoord(key);
+        if ((voxel_coordinate - sensor_origin).norm() < params_.max_free_space ||
+	        voxel_coordinate.z() > (sensor_origin.z() - params_.min_height_free_space)) {
           free_cells->insert(key);
         }
       }
@@ -183,7 +185,13 @@ void OctomapWorld::castRay(const octomap::point3d& sensor_origin,
         (point - sensor_origin).normalized() * params_.sensor_max_range;
     octomap::KeyRay key_ray;
     if (octree_->computeRayKeys(sensor_origin, new_end, key_ray)) {
-      free_cells->insert(key_ray.begin(), key_ray.end());
+      for (const auto& key: key_ray) {
+	    octomap::point3d voxel_coordinate = octree_->keyToCoord(key);
+        if ((voxel_coordinate - sensor_origin).norm() < params_.max_free_space ||
+	        voxel_coordinate.z() > (sensor_origin.z() - params_.min_height_free_space)) {
+          free_cells->insert(key);
+        }
+      }
     }
   }
 }

--- a/octomap_world/src/octomap_world.cc
+++ b/octomap_world/src/octomap_world.cc
@@ -165,11 +165,15 @@ void OctomapWorld::castRay(const octomap::point3d& sensor_origin,
     // Cast a ray to compute all the free cells.
     octomap::KeyRay key_ray;
     if (octree_->computeRayKeys(sensor_origin, point, key_ray)) {
-      for (const auto& key: key_ray) {
-	    octomap::point3d voxel_coordinate = octree_->keyToCoord(key);
-        if ((voxel_coordinate - sensor_origin).norm() < params_.max_free_space ||
-	        voxel_coordinate.z() > (sensor_origin.z() - params_.min_height_free_space)) {
-          free_cells->insert(key);
+      if (params_.max_free_space == 0.0) {
+        free_cells->insert(key_ray.begin(), key_ray.end());
+      } else {
+        for (const auto& key: key_ray) {
+          octomap::point3d voxel_coordinate = octree_->keyToCoord(key);
+          if ((voxel_coordinate - sensor_origin).norm() < params_.max_free_space ||
+              voxel_coordinate.z() > (sensor_origin.z() - params_.min_height_free_space)) {
+            free_cells->insert(key);
+          }
         }
       }
     }
@@ -185,11 +189,15 @@ void OctomapWorld::castRay(const octomap::point3d& sensor_origin,
         (point - sensor_origin).normalized() * params_.sensor_max_range;
     octomap::KeyRay key_ray;
     if (octree_->computeRayKeys(sensor_origin, new_end, key_ray)) {
-      for (const auto& key: key_ray) {
-	    octomap::point3d voxel_coordinate = octree_->keyToCoord(key);
-        if ((voxel_coordinate - sensor_origin).norm() < params_.max_free_space ||
-	        voxel_coordinate.z() > (sensor_origin.z() - params_.min_height_free_space)) {
-          free_cells->insert(key);
+      if (params_.max_free_space == 0.0) {
+        free_cells->insert(key_ray.begin(), key_ray.end());
+      } else {
+        for (const auto& key: key_ray) {
+          octomap::point3d voxel_coordinate = octree_->keyToCoord(key);
+          if ((voxel_coordinate - sensor_origin).norm() < params_.max_free_space ||
+              voxel_coordinate.z() > (sensor_origin.z() - params_.min_height_free_space)) {
+            free_cells->insert(key);
+          }
         }
       }
     }


### PR DESCRIPTION
@helenol we added this as we had an issue that the ground plane was removed over time by the ray casting for NiFTI. As the sensor is low to the floor, far measurements on lower part of walls will set a bunch of voxels as free space. These are not removed from the free space list with the strategy exaplained in the paper http://www2.informatik.uni-freiburg.de/~hornunga/pub/hornung13auro.pdf see fig 10 and 11 as there is a region where we get no measurements on the ground. We get eg. ground measurements for the first 5 meters, then nothing, then a measurement on a wall which is far.

This addition does not update the voxels as free space if they are above a certain distance. It is not perfect but this will be hard to solve without a strong heuristic. Is this something which you observed before? Is that a feature which would be interesting to add in master? Thanks! :) 