### PR TITLE
Add box output for occupied/free nodes

### DIFF
--- a/octomap_world/include/octomap_world/octomap_world.h
+++ b/octomap_world/include/octomap_world/octomap_world.h
@@ -139,6 +139,13 @@ class OctomapWorld : public WorldBase {
       const Eigen::Vector3d& center, const Eigen::Vector3d& bounding_box_size,
       pcl::PointCloud<pcl::PointXYZ>* output_cloud) const;
 
+  // Structure: vector of pairs, key is the cube center and double is the
+  // dimension of each side.
+  void getAllFreeBoxes(
+      std::vector<std::pair<Eigen::Vector3d, double> >* free_box_vector) const;
+  void getAllOccupiedBoxes(std::vector<std::pair<Eigen::Vector3d, double> >*
+                               occupied_box_vector) const;
+
   virtual double getResolution() const;
   virtual Eigen::Vector3d getMapCenter() const;
   virtual Eigen::Vector3d getMapSize() const;
@@ -198,6 +205,10 @@ class OctomapWorld : public WorldBase {
   void setLogOddsBoundingBox(const Eigen::Vector3d& position,
                              const Eigen::Vector3d& bounding_box_size,
                              double log_odds_value);
+
+  void getAllBoxes(
+      bool occupied_boxes,
+      std::vector<std::pair<Eigen::Vector3d, double> >* box_vector) const;
 
   // Helper functions for building up a map from sensor data.
   void castRay(const octomap::point3d& sensor_origin,

--- a/octomap_world/src/octomap_world.cc
+++ b/octomap_world/src/octomap_world.cc
@@ -1,6 +1,6 @@
 /*
-Copyright (c) 2011, Markus Achtelik, ASL, ETH Zurich, Switzerland
-You can contact the author at <markus dot achtelik at mavt dot ethz dot ch>
+Copyright (c) 2015, Helen Oleynikova, ETH Zurich, Switzerland
+You can contact the author at <helen dot oleynikova at mavt dot ethz dot ch>
 
 All rights reserved.
 
@@ -488,6 +488,38 @@ void OctomapWorld::getOccupiedPointcloudInBoundingBox(
               pcl::PointXYZ(point.x(), point.y(), point.z()));
         }
       }
+    }
+  }
+}
+
+void OctomapWorld::getAllFreeBoxes(
+    std::vector<std::pair<Eigen::Vector3d, double> >* free_box_vector) const {
+  const bool occupied_boxes = false;
+  getAllBoxes(occupied_boxes, free_box_vector);
+}
+
+void OctomapWorld::getAllOccupiedBoxes(
+    std::vector<std::pair<Eigen::Vector3d, double> >* occupied_box_vector)
+    const {
+  const bool occupied_boxes = true;
+  getAllBoxes(occupied_boxes, occupied_box_vector);
+}
+
+void OctomapWorld::getAllBoxes(
+    bool occupied_boxes,
+    std::vector<std::pair<Eigen::Vector3d, double> >* box_vector) const {
+  box_vector->clear();
+  for (octomap::OcTree::leaf_iterator it = octree_->begin_leafs(),
+                                      end = octree_->end_leafs();
+       it != end; ++it) {
+    Eigen::Vector3d cube_center(it.getX(), it.getY(), it.getZ());
+    int depth_level = it.getDepth();
+    double cube_size = octree_->getNodeSize(depth_level);
+
+    if (octree_->isNodeOccupied(*it) && occupied_boxes) {
+      box_vector->emplace_back(cube_center, cube_size);
+    } else if (!octree_->isNodeOccupied(*it) && !occupied_boxes) {
+      box_vector->emplace_back(cube_center, cube_size);
     }
   }
 }

--- a/octomap_world/src/octomap_world.cc
+++ b/octomap_world/src/octomap_world.cc
@@ -509,6 +509,7 @@ void OctomapWorld::getAllBoxes(
     bool occupied_boxes,
     std::vector<std::pair<Eigen::Vector3d, double> >* box_vector) const {
   box_vector->clear();
+  box_vector->reserve(octree_->size());
   for (octomap::OcTree::leaf_iterator it = octree_->begin_leafs(),
                                       end = octree_->end_leafs();
        it != end; ++it) {


### PR DESCRIPTION
@SebastianInd 

Quick example of how to use this:
```C++
  std::vector<std::pair<Eigen::Vector3d, double> > box_vector;
  octomap_world_->getAllFreedBoxes(&box_vector);
  for (const std::pair<Eigen::Vector3d, double>& box : box_vector) {
    std::cout << "Box center: " << box.first.transpose()
              << " box size: " << box.second << std::endl;
  }
```